### PR TITLE
Fix version settings and script error on startup

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+PURPLE="\033[0;35m"
+RESET="\033[0m"
+
 set -e
 
 . "$(dirname "$0")/consts.sh"
@@ -25,7 +28,16 @@ if [ "$CURR_VER" == "$VERSION+$BUILD" ] && [ "$USE_CACHE" == "true" ]; then
     exit 0
 fi
 
-RES=$(curl -sL "$API_ENDPOINT/projects/paper/versions/$VERSION/builds/$BUILD")
+set +e
+RES=$(curl -sLf "$API_ENDPOINT/projects/paper/versions/$VERSION/builds/$BUILD")
+status=$?
+set -e
+
+if [ $status -ne 0 ]; then
+    echo -e "${PURPLE}ERROR: No build with version $VERSION and build $BUILD existent!${RESET}"
+    echo "Download Url: $API_ENDPOINT/projects/paper/versions/$VERSION/builds/$BUILD"
+    exit 2
+fi
 jar_name=$(echo "$RES" | jq -rM '.downloads.application.name')
 
 curl -Lo paper.jar "$API_ENDPOINT/projects/paper/versions/$VERSION/builds/$BUILD/downloads/$jar_name"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,7 +15,7 @@ if [ -z "$VERSION" ] || [ "$VERSION" == "latest" ]; then
 fi
 
 if [ -z "$BUILD" ] || [ "$BUILD" == "latest" ]; then
-    BUILD=$(sh "$(dirname "$0")"/get-latest-build.sh "$VERSION")
+    BUILD=$(bash "$(dirname "$0")"/get-latest-build.sh "$VERSION")
 fi
 
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-PURPLE="\033[0;35m"
-RESET="\033[0m"
+source ./scripts/utils.sh
 
 set -e
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,10 +6,6 @@ set -e
 
 CURR_VER_FILE="/tmp/current-server-version"
 
-VERSION=$1
-BUILD=$2
-USE_CACHE=$3
-
 if [ -z "$VERSION" ] || [ "$VERSION" == "latest" ]; then
     VERSION=$(sh "$(dirname "$0")"/get-latest-version.sh)
 fi

--- a/scripts/get-latest-build.sh
+++ b/scripts/get-latest-build.sh
@@ -4,8 +4,6 @@ set -e
 
 . "$(dirname "$0")/consts.sh"
 
-VERSION=$1
-
 if [ -z "$VERSION" ] || [ "$VERSION" == "latest" ]; then
     VERSION=$(sh "$(dirname "$0")"/get-latest-version.sh)
 fi


### PR DESCRIPTION
This PR fixes the error that the settings are ignored #2 and also deals with the error when starting the application #3.

This PR restores the expected behavior and builds and starts the specified version. If the version and/or the build number is not found, an error is now displayed and the container aborts the start process with error code 2.

To test the change, these commands can be used to achieve the different results:

Latest version: ``docker run --rm -e VERSION=latest ghcr.io/zekrotja/papermc-docker:latest``
Specified version: ``docker run --rm -e VERSION=1.17.1 ghcr.io/zekrotja/papermc-docker:latest``
Non-existent version:``docker run --rm -e VERSION=1.20.0 ghcr.io/zekrotja/papermc-docker:latest``

The same applies to the build number or the combination of both.