### PR TITLE
Update scripts to PaperMC API v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM ghcr.io/zekrotja/minebase:$MINEBASE_IMAGE
 
 COPY scripts/ scripts/
 
+RUN dos2unix ./scripts/*.sh /usr/bin/rcon
 RUN chmod +x scripts/*.sh
 
 RUN mkdir -p /var/mcserver && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ ARG MINEBASE_IMAGE="jdk-21"
 
 FROM ghcr.io/zekrotja/minebase:$MINEBASE_IMAGE
 
+RUN apt-get update -y &&\
+    apt-get install -y coreutils
+
 COPY scripts/ scripts/
 
 RUN dos2unix ./scripts/*.sh /usr/bin/rcon

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,8 @@ services:
       - "25565:25565"
       - "25575:25575"
     environment:
-      VERSION: "1.21.7"
-      BUILD: "31"
+      VERSION: "latest"
+      BUILD: "latest"
       CACHE_DOWNLOAD: "true"
       XMS: "1G"
       XMX: "2G"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,8 @@ services:
       - "25565:25565"
       - "25575:25575"
     environment:
-      VERSION: "latest"
-      BUILD: "latest"
+      VERSION: "1.21.7"
+      BUILD: "31"
       CACHE_DOWNLOAD: "true"
       XMS: "1G"
       XMX: "2G"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,7 +17,7 @@ if [ -z "$VERSION" ] || [ "$VERSION" == "latest" ]; then
 fi
 
 if [ -z "$BUILD" ] || [ "$BUILD" == "latest" ]; then
-    BUILD=$(bash "$(dirname "$0")"/get-latest-build.sh "$VERSION")
+    BUILD=$(bash "$(dirname "$0")"/get-latest-build.sh)
 fi
 
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,7 +13,7 @@ set -e
 CURR_VER_FILE="/tmp/current-server-version"
 
 if [ -z "$VERSION" ] || [ "$VERSION" == "latest" ]; then
-    VERSION=$(sh "$(dirname "$0")"/get-latest-version.sh)
+    VERSION=$(bash "$(dirname "$0")"/get-latest-version.sh)
 fi
 
 if [ -z "$BUILD" ] || [ "$BUILD" == "latest" ]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -58,7 +58,7 @@ if [ "$JAR_DOWNLOAD_URL" = "null" ]; then
   exit 3
 fi
 
-# Download the latest Paper version
+# Download the specified Paper version
 curl -Lo paper.jar "$JAR_DOWNLOAD_URL"
 
 echo "$VERSION+$BUILD" > $CURR_VER_FILE

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,20 +20,15 @@ if [ -z "$BUILD" ] || [ "$BUILD" == "latest" ]; then
     BUILD=$(bash "$(dirname "$0")"/get-latest-build.sh)
 fi
 
-
-echo "Paper version $VERSION+$BUILD"
-echo "-----------------------------"
+echo -e "[ ${CYAN}INFO${RESET} ] Using Paper version: $VERSION+$BUILD"
+echo -e "[ ${CYAN}INFO${RESET} ] -----------------------------"
 
 CURR_VER=$([ -f "$CURR_VER_FILE" ] && cat "$CURR_VER_FILE" || echo "")
 
 if [ "$CURR_VER" == "$VERSION+$BUILD" ] && [ "$USE_CACHE" == "true" ]; then
-    echo "Using binary from cache..."
+    echo -e "[ ${CYAN}INFO${RESET} ] Using binary from cache."
     exit 0
 fi
-
-# This query is based on the example published by papermc.
-# https://docs.papermc.io/misc/downloads-api/#downloading-the-latest-stable-build
-# Archived version: https://web.archive.org/web/20250726220949/https://docs.papermc.io/misc/downloads-api/#downloading-the-latest-stable-build
 
 BUILD_INFO_URL="${API_ENDPOINT}/projects/paper/versions/${VERSION}/builds/$BUILD"
 BUILD_INFO=$(curl -s -H "User-Agent: $USER_AGENT" "${BUILD_INFO_URL}")
@@ -41,47 +36,42 @@ BUILD_INFO=$(curl -s -H "User-Agent: $USER_AGENT" "${BUILD_INFO_URL}")
 # Check if the API returned an error
 if echo "$BUILD_INFO" | jq -e '.ok == false' > /dev/null 2>&1; then
   ERROR_MSG=$(echo "$BUILD_INFO" | jq -r '.message // "Unknown error"')
-  echo -e "[ ${PURPLE}ERROR ${RESET}]${PURPLE} Error with version $VERSION and build $BUILD!${RESET}"
-  echo -e "[ ${PURPLE}ERROR ${RESET}]${PURPLE} $ERROR_MSG${RESET}"
-  echo -e "[ ${PURPLE}ERROR ${RESET}]${PURPLE} Used build info url: ${BUILD_INFO_URL}${RESET}"
+  echo -e "[ ${PURPLE}ERROR${RESET} ] Failed to retrieve build info for version $VERSION, build $BUILD."
+  echo -e "[ ${PURPLE}ERROR${RESET} ] $ERROR_MSG"
+  echo -e "[ ${PURPLE}ERROR${RESET} ] Build info URL: $BUILD_INFO_URL"
   exit 2
 fi
 
 JAR_DOWNLOAD_URL=$(echo "$BUILD_INFO" | jq -r '.downloads."server:default".url')
 
-# Check if download url is provided
 if [ "$JAR_DOWNLOAD_URL" = "null" ]; then
-  echo -e "[ ${PURPLE}ERROR ${RESET}]${PURPLE} Error with version $VERSION and build $BUILD!${RESET}"
-  echo -e "[ ${PURPLE}ERROR ${RESET}]${PURPLE} No download url was provided by PaperMC!${RESET}"
-  echo -e "[ ${PURPLE}ERROR ${RESET}]${PURPLE} Used build info url: ${BUILD_INFO_URL}${RESET}"
+  echo -e "[ ${PURPLE}ERROR${RESET} ] No download URL provided for version $VERSION, build $BUILD."
+  echo -e "[ ${PURPLE}ERROR${RESET} ] Build info URL: $BUILD_INFO_URL"
   exit 3
 fi
 
 # Download the specified Paper version
-curl -Lo paper.jar "$JAR_DOWNLOAD_URL"
-echo -e "[ ${CYAN}INFO ${RESET}]${CYAN} Download completed${RESET}"
+echo -e "[ ${CYAN}INFO${RESET} ] Starting jar download."
+curl -Lso paper.jar "$JAR_DOWNLOAD_URL"
+echo -e "[ ${CYAN}INFO${RESET} ] Download completed successfully."
 
-
-# Testing checkum
+# Checksum verification
 EXPECTED_CHECKSUM=$(echo "$BUILD_INFO" | jq -r '.downloads."server:default".checksums.sha256')
 
-
 if [ "$EXPECTED_CHECKSUM" = "null" ] || [ -z "$EXPECTED_CHECKSUM" ]; then
-  echo "No stable build for version $MINECRAFT_VERSION found :("
-  echo -e "[ ${CYAN}WARN ${RESET}]${CYAN} No checksum was provided by PaperMC!${RESET}"
-  echo -e "[ ${CYAN}WARN ${RESET}]${CYAN} Skipping checksum test!${RESET}"
+  echo -e "[ ${CYAN}WARN${RESET} ] No checksum provided by PaperMC — skipping verification."
 else
-  echo -e "[ ${CYAN}INFO ${RESET}]${CYAN} Checking checksum${RESET}"
+  echo -e "[ ${CYAN}INFO${RESET} ] Verifying checksum..."
   ACTUAL_CHECKSUM=$(sha256sum "paper.jar" | awk '{print $1}')
 
   if [ "$EXPECTED_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
-    echo -e "[ ${CYAN}INFO${RESET} ] ${CYAN}Checksums matched${RESET}"
+    echo -e "[ ${CYAN}INFO${RESET} ] Checksum verification passed."
   else
-    echo -e "[ ${PURPLE}ERROR${RESET} ] ${PURPLE}Integrity check failed. Aborting.${RESET}"
-    echo -e "[ ${PURPLE}ERROR${RESET} ] ${PURPLE}Expected checksum: $EXPECTED_CHECKSUM${RESET}"
-    echo -e "[ ${PURPLE}ERROR${RESET} ] ${PURPLE}Actual checksum:   $ACTUAL_CHECKSUM${RESET}"
-    echo -e "[ ${PURPLE}ERROR${RESET} ] ${PURPLE}Used build info url: ${BUILD_INFO_URL}${RESET}"
-    echo -e "[ ${PURPLE}ERROR${RESET} ] ${PURPLE}Used download url: ${JAR_DOWNLOAD_URL}${RESET}"
+    echo -e "[ ${PURPLE}ERROR${RESET} ] Checksum mismatch detected!"
+    echo -e "[ ${PURPLE}ERROR${RESET} ] Expected: $EXPECTED_CHECKSUM"
+    echo -e "[ ${PURPLE}ERROR${RESET} ] Actual:   $ACTUAL_CHECKSUM"
+    echo -e "[ ${PURPLE}ERROR${RESET} ] Build info URL: $BUILD_INFO_URL"
+    echo -e "[ ${PURPLE}ERROR${RESET} ] Download URL:   $JAR_DOWNLOAD_URL"
     exit 4
   fi
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -41,8 +41,9 @@ BUILD_INFO=$(curl -s -H "User-Agent: $USER_AGENT" "${BUILD_INFO_URL}")
 # Check if the API returned an error
 if echo "$BUILD_INFO" | jq -e '.ok == false' > /dev/null 2>&1; then
   ERROR_MSG=$(echo "$BUILD_INFO" | jq -r '.message // "Unknown error"')
-  echo "Error: $ERROR_MSG"
-  echo "Build info url: ${BUILD_INFO_URL}"
+  echo -e "[ ${PURPLE}ERROR ${RESET}]${PURPLE} Error with version $VERSION and build $BUILD!${RESET}"
+  echo -e "[ ${PURPLE}ERROR ${RESET}]${PURPLE} $ERROR_MSG${RESET}"
+  echo -e "[ ${PURPLE}ERROR ${RESET}]${PURPLE} Used build info url: ${BUILD_INFO_URL}${RESET}"
   exit 2
 fi
 
@@ -51,6 +52,9 @@ JAR_DOWNLOAD_URL=$(echo "$BUILD_INFO" | jq -r '.downloads."server:default".url')
 # Check if download url is provided
 if [ "$JAR_DOWNLOAD_URL" = "null" ]; then
   echo "No stable build for version $MINECRAFT_VERSION found :("
+  echo -e "[ ${PURPLE}ERROR ${RESET}]${PURPLE} Error with version $VERSION and build $BUILD!${RESET}"
+  echo -e "[ ${PURPLE}ERROR ${RESET}]${PURPLE} No download url is provided by papermc!${RESET}"
+  echo -e "[ ${PURPLE}ERROR ${RESET}]${PURPLE} Used build info url: ${BUILD_INFO_URL}${RESET}"
   exit 3
 fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -59,5 +59,31 @@ fi
 
 # Download the specified Paper version
 curl -Lo paper.jar "$JAR_DOWNLOAD_URL"
+echo -e "[ ${CYAN}INFO ${RESET}]${CYAN} Download completed${RESET}"
+
+
+# Testing checkum
+EXPECTED_CHECKSUM=$(echo "$BUILD_INFO" | jq -r '.downloads."server:default".checksums.sha256')
+
+
+if [ "$EXPECTED_CHECKSUM" = "null" ] || [ -z "$EXPECTED_CHECKSUM" ]; then
+  echo "No stable build for version $MINECRAFT_VERSION found :("
+  echo -e "[ ${CYAN}WARN ${RESET}]${CYAN} No checksum was provided by PaperMC!${RESET}"
+  echo -e "[ ${CYAN}WARN ${RESET}]${CYAN} Skipping checksum test!${RESET}"
+else
+  echo -e "[ ${CYAN}INFO ${RESET}]${CYAN} Checking checksum${RESET}"
+  ACTUAL_CHECKSUM=$(sha256sum "paper.jar" | awk '{print $1}')
+
+  if [ "$EXPECTED_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
+    echo -e "[ ${CYAN}INFO${RESET} ] ${CYAN}Checksums matched${RESET}"
+  else
+    echo -e "[ ${PURPLE}ERROR${RESET} ] ${PURPLE}Integrity check failed. Aborting.${RESET}"
+    echo -e "[ ${PURPLE}ERROR${RESET} ] ${PURPLE}Expected checksum: $EXPECTED_CHECKSUM${RESET}"
+    echo -e "[ ${PURPLE}ERROR${RESET} ] ${PURPLE}Actual checksum:   $ACTUAL_CHECKSUM${RESET}"
+    echo -e "[ ${PURPLE}ERROR${RESET} ] ${PURPLE}Used build info url: ${BUILD_INFO_URL}${RESET}"
+    echo -e "[ ${PURPLE}ERROR${RESET} ] ${PURPLE}Used download url: ${JAR_DOWNLOAD_URL}${RESET}"
+    exit 4
+  fi
+fi
 
 echo "$VERSION+$BUILD" > $CURR_VER_FILE

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,7 +24,7 @@ fi
 echo "Paper version $VERSION+$BUILD"
 echo "-----------------------------"
 
-CURR_VER=$([ -f $CURR_VER_FILE ] && cat $CURR_VER_FILE || echo "")
+CURR_VER=$([ -f "$CURR_VER_FILE" ] && cat "$CURR_VER_FILE" || echo "")
 
 if [ "$CURR_VER" == "$VERSION+$BUILD" ] && [ "$USE_CACHE" == "true" ]; then
     echo "Using binary from cache..."
@@ -86,4 +86,4 @@ else
   fi
 fi
 
-echo "$VERSION+$BUILD" > $CURR_VER_FILE
+echo "$VERSION+$BUILD" > "$CURR_VER_FILE"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -51,9 +51,8 @@ JAR_DOWNLOAD_URL=$(echo "$BUILD_INFO" | jq -r '.downloads."server:default".url')
 
 # Check if download url is provided
 if [ "$JAR_DOWNLOAD_URL" = "null" ]; then
-  echo "No stable build for version $MINECRAFT_VERSION found :("
   echo -e "[ ${PURPLE}ERROR ${RESET}]${PURPLE} Error with version $VERSION and build $BUILD!${RESET}"
-  echo -e "[ ${PURPLE}ERROR ${RESET}]${PURPLE} No download url is provided by papermc!${RESET}"
+  echo -e "[ ${PURPLE}ERROR ${RESET}]${PURPLE} No download url was provided by PaperMC!${RESET}"
   echo -e "[ ${PURPLE}ERROR ${RESET}]${PURPLE} Used build info url: ${BUILD_INFO_URL}${RESET}"
   exit 3
 fi

--- a/scripts/consts.sh
+++ b/scripts/consts.sh
@@ -1,1 +1,2 @@
-API_ENDPOINT="https://api.papermc.io/v2"
+API_ENDPOINT="https://fill.papermc.io/v3"
+API_USER_AGENT="github.com/zekroTJA/papermc-docker"

--- a/scripts/consts.sh
+++ b/scripts/consts.sh
@@ -1,2 +1,2 @@
 API_ENDPOINT="https://fill.papermc.io/v3"
-API_USER_AGENT="github.com/zekroTJA/papermc-docker"
+API_USER_AGENT="papermc-docker (github.com/zekroTJA/papermc-docker)"

--- a/scripts/get-latest-build.sh
+++ b/scripts/get-latest-build.sh
@@ -14,6 +14,16 @@ if [ -z "$VERSION" ] || [ "$VERSION" == "latest" ]; then
     VERSION=$(sh "$(dirname "$0")"/get-latest-version.sh)
 fi
 
-RES=$(curl -sL "$API_ENDPOINT/projects/paper/versions/$VERSION")
-echo "$RES" | jq -rM '.builds[-1]'
+# This query is based on the example published by papermc.
+# https://docs.papermc.io/misc/downloads-api/#getting-the-latest-stable-build-number
+# Archived version: https://web.archive.org/web/20250726220949/https://docs.papermc.io/misc/downloads-api/#getting-the-latest-stable-build-number
 
+LATEST_BUILD=$(curl -s -H "User-Agent: $USER_AGENT" "${API_ENDPOINT}/projects/paper/versions/${VERSION}/builds" | \
+  jq -r 'map(select(.channel == "STABLE")) | .[0] | .id')
+
+if [ "$LATEST_BUILD" != "null" ]; then
+  echo "$LATEST_BUILD"
+else
+  echo "No stable build for version $MINECRAFT_VERSION found"
+  exit 1
+fi

--- a/scripts/get-latest-version.sh
+++ b/scripts/get-latest-version.sh
@@ -10,8 +10,11 @@ set -e
 
 . "$(dirname "$0")/consts.sh"
 
-RES=$(curl -sL "$API_ENDPOINT/projects/paper")
+# This query is based on the example published by papermc.
+# https://docs.papermc.io/misc/downloads-api/#getting-the-latest-version
+# Archived version: https://web.archive.org/web/20250726220949/https://docs.papermc.io/misc/downloads-api/#getting-the-latest-version
 
-echo "$RES" | jq -rM '.versions[-1]'
+LATEST_VERSION=$(curl -s -H "User-Agent: $API_USER_AGENT" "${API_ENDPOINT}/projects/paper" | \
+    jq -r '.versions | to_entries[0] | .value[0]')
 
-
+echo "$LATEST_VERSION"


### PR DESCRIPTION
This PR migrates the current scripts to the updated v3 API version of PaperMC.
The scripts have been adapted according to the recommended approach from PaperMC’s [Downloads API Docs](https://docs.papermc.io/misc/downloads-api/).   

A User-Agent header has been added and can be found in the file `scripts/consts.sh`. Please review it carefully, as I couldn’t find a straightforward way to derive the User-Agent from the GitHub repository.  

Additionally, the checksum of the downloaded file is now verified, if a checksum is provided by PaperMC.  

## Log impressions
<details>
  <summary>Normal start</summary>
  
  <img width="1920" height="1032" alt="{7F6E9E34-5F70-4FC0-A84E-F5BBC3C92C94}" src="https://github.com/user-attachments/assets/c93b5cb8-3884-44d1-927d-e55ee176af43" />
</details>
<details>
  <summary>Failed to retrieve build info for version 1.21.8, build 55</summary>

  <img width="1920" height="1032" alt="{883B0EEA-12D8-4830-B475-709FEF5DBDE1}" src="https://github.com/user-attachments/assets/97e1999d-466b-4afc-8fcb-b2d010285de4" />
</details>
<details>
  <summary>No download URL provided for version 1.21.8, build 17 (simulated)</summary>

  <img width="1920" height="1032" alt="{02639924-9AD9-48CD-BD22-55228D560317}" src="https://github.com/user-attachments/assets/f4760356-fe81-4ca5-8912-6f4c1ff24f0d" />
</details>
<details>
  <summary>No checksum provided by PaperMC (simulated)</summary>

  <img width="1920" height="1032" alt="{98720E17-7F77-4FF5-BED4-F22BC5288224}" src="https://github.com/user-attachments/assets/3f457f41-5a76-437c-b0eb-0a9921041762" />
</details>
<details>
  <summary>Checksum mismatch detected (simulated)</summary>

  <img width="1920" height="1032" alt="{EF174334-8E4B-437A-A76A-857D81023C64}" src="https://github.com/user-attachments/assets/0705ec2c-4703-4d2e-b48f-0b05938b76c1" />
</details>