### PR TITLE
Show get latest build error message

### DIFF
--- a/scripts/get-latest-build.sh
+++ b/scripts/get-latest-build.sh
@@ -24,6 +24,6 @@ LATEST_BUILD=$(curl -s -H "User-Agent: $USER_AGENT" "${API_ENDPOINT}/projects/pa
 if [ "$LATEST_BUILD" != "null" ]; then
   echo "$LATEST_BUILD"
 else
-  echo "No stable build for version $MINECRAFT_VERSION found"
+  echo "No stable build for version $VERSION found" >&2
   exit 1
 fi


### PR DESCRIPTION
The get-latest-build.sh script outputs an error message if no stable build can be found. However, this error message is intercepted by https://github.com/zekroTJA/papermc-docker/blob/12b8c0fdfde168d9f88ef4be3721bd3ab97052da/scripts/build.sh#L20 and stored in the BUILD variable. 

This means that no error message can be found in the Docker log except for an exit 1.

With this PR, I redirect the message to stderr so that the error message appears in the logs. 

Minecraft version 1.20.5, for example, does not have a stable build and therefore serves as an example here.

Old behaviour:
```bash
> docker run --rm -e "VERSION=1.20.5" ghcr.io/zekrotja/papermc-docker:jdk-21

[ INFO ] Backup is disabled
```

New behaviour:
```bash
> docker compose run --remove-orphans --build papermc

[ INFO ] Backup is disabled
No stable build for version 1.20.5 found

```